### PR TITLE
Add the sphinx_copybutton extension

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx_rtd_theme
 sphinx_autodoc_typehints
+sphinx_copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,8 @@ extensions = ['sphinx.ext.duration',
               'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx',
               'sphinx.ext.viewcode',
-              'sphinx_autodoc_typehints']
+              'sphinx_autodoc_typehints',
+              'sphinx_copybutton']
 
 # Source: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-source_suffix
 source_suffix = {'.rst': 'restructuredtext', }


### PR DESCRIPTION
Add the [sphinx_copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/) extension to the docs.

This lightweight utility is a one-liner that adds copy buttons to code blocks, which makes the documentation significantly more user-friendly:

![image](https://github.com/bessagroup/bessa-pypi-template/assets/25569517/6b4a2183-780a-41ea-8a88-2db4c18e69db)

